### PR TITLE
[FLINK-36039][autoscaler] Support clean historical event handler records in autoscaler standalone

### DIFF
--- a/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/event/AbstractJdbcAutoscalerEventHandlerITCase.java
+++ b/flink-autoscaler-plugin-jdbc/src/test/java/org/apache/flink/autoscaler/jdbc/event/AbstractJdbcAutoscalerEventHandlerITCase.java
@@ -69,7 +69,7 @@ abstract class AbstractJdbcAutoscalerEventHandlerITCase implements DatabaseTest 
     void beforeEach() throws Exception {
         jdbcEventInteractor = new CountableJdbcEventInteractor(getConnection());
         jdbcEventInteractor.setClock(Clock.fixed(createTime, ZoneId.systemDefault()));
-        eventHandler = new JdbcAutoScalerEventHandler<>(jdbcEventInteractor);
+        eventHandler = new JdbcAutoScalerEventHandler<>(jdbcEventInteractor, Duration.ZERO);
         ctx = createDefaultJobAutoScalerContext();
     }
 

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactory.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/AutoscalerEventHandlerFactory.java
@@ -27,6 +27,8 @@ import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.DescribedEnum;
 import org.apache.flink.configuration.description.InlineElement;
 
+import java.time.Duration;
+
 import static org.apache.flink.autoscaler.standalone.AutoscalerEventHandlerFactory.EventHandlerType.JDBC;
 import static org.apache.flink.autoscaler.standalone.AutoscalerEventHandlerFactory.EventHandlerType.LOGGING;
 import static org.apache.flink.autoscaler.standalone.config.AutoscalerStandaloneOptions.EVENT_HANDLER_TYPE;
@@ -73,6 +75,6 @@ public class AutoscalerEventHandlerFactory {
             AutoScalerEventHandler<KEY, Context> createJdbcEventHandler(Configuration conf)
                     throws Exception {
         var conn = HikariJDBCUtil.getConnection(conf);
-        return new JdbcAutoScalerEventHandler<>(new JdbcEventInteractor(conn));
+        return new JdbcAutoScalerEventHandler<>(new JdbcEventInteractor(conn), Duration.ZERO);
     }
 }

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/StandaloneAutoscalerExecutor.java
@@ -113,6 +113,8 @@ public class StandaloneAutoscalerExecutor<KEY, Context extends JobAutoScalerCont
     public void close() {
         scheduledExecutorService.shutdownNow();
         scalingThreadPool.shutdownNow();
+        autoScaler.close();
+        eventHandler.close();
     }
 
     /**

--- a/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/config/AutoscalerStandaloneOptions.java
+++ b/flink-autoscaler-standalone/src/main/java/org/apache/flink/autoscaler/standalone/config/AutoscalerStandaloneOptions.java
@@ -121,4 +121,11 @@ public class AutoscalerStandaloneOptions {
                                             code(EVENT_HANDLER_TYPE.key()),
                                             code("JDBC"))
                                     .build());
+
+    public static final ConfigOption<Duration> JDBC_EVENT_HANDLER_TTL =
+            autoscalerStandaloneConfig("jdbc-event-handler.ttl")
+                    .durationType()
+                    .defaultValue(Duration.ofDays(90))
+                    .withDescription(
+                            "The time to live based on create time for the JDBC event handler records. When the config is set as '0', the ttl strategy for the records would be disabled.");
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScaler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScaler.java
@@ -19,6 +19,8 @@ package org.apache.flink.autoscaler;
 
 import org.apache.flink.annotation.Internal;
 
+import java.io.Closeable;
+
 /**
  * Flink Job AutoScaler.
  *
@@ -26,7 +28,7 @@ import org.apache.flink.annotation.Internal;
  * @param <Context> Instance of {@link JobAutoScalerContext}.
  */
 @Internal
-public interface JobAutoScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
+public interface JobAutoScaler<KEY, Context extends JobAutoScalerContext<KEY>> extends Closeable {
 
     /**
      * Compute and apply new parallelism overrides for the provided job context.
@@ -42,4 +44,7 @@ public interface JobAutoScaler<KEY, Context extends JobAutoScalerContext<KEY>> {
      * @param jobKey Job key.
      */
     void cleanup(KEY jobKey);
+
+    /** Close the related resource. */
+    default void close() {}
 }

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/JobAutoScalerImpl.java
@@ -126,6 +126,11 @@ public class JobAutoScalerImpl<KEY, Context extends JobAutoScalerContext<KEY>>
         stateStore.removeInfoFromCache(jobKey);
     }
 
+    @Override
+    public void close() {
+        eventHandler.close();
+    }
+
     @VisibleForTesting
     protected Map<String, String> getParallelismOverrides(Context ctx) throws Exception {
         return stateStore.getParallelismOverrides(ctx);

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoScalerEventHandler.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/event/AutoScalerEventHandler.java
@@ -27,6 +27,7 @@ import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import javax.annotation.Nullable;
 
+import java.io.Closeable;
 import java.time.Duration;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -42,7 +43,8 @@ import static org.apache.flink.autoscaler.metrics.ScalingMetric.TRUE_PROCESSING_
  * @param <Context> Instance of JobAutoScalerContext.
  */
 @Experimental
-public interface AutoScalerEventHandler<KEY, Context extends JobAutoScalerContext<KEY>> {
+public interface AutoScalerEventHandler<KEY, Context extends JobAutoScalerContext<KEY>>
+        extends Closeable {
     String SCALING_SUMMARY_ENTRY =
             "{ Vertex ID %s | Parallelism %d -> %d | Processing capacity %.2f -> %.2f | Target data rate %.2f}";
     String SCALING_EXECUTION_DISABLED_REASON = "%s:%s, recommended parallelism change:";
@@ -98,6 +100,9 @@ public interface AutoScalerEventHandler<KEY, Context extends JobAutoScalerContex
                 SCALING_REPORT_KEY,
                 interval);
     }
+
+    /** Close the related resource. */
+    default void close() {}
 
     static String scalingReport(Map<JobVertexID, ScalingSummary> scalingSummaries, String message) {
         StringBuilder sb = new StringBuilder(message);


### PR DESCRIPTION

<!--
*Thank you very much for contributing to the Apache Flink Kubernetes Operator - we are happy that you want to help us improve the project. To help the community review your contribution in the best possible way, please go through the checklist below, which will get the contribution into a shape in which it can be best reviewed.*

## Contribution Checklist

  - Make sure that the pull request corresponds to a [JIRA issue](https://issues.apache.org/jira/projects/FLINK/issues). Exceptions are made for typos in JavaDoc or documentation files, which need no JIRA issue.
  
  - Name the pull request in the form "[FLINK-XXXX] [component] Title of the pull request", where *FLINK-XXXX* should be replaced by the actual issue number. Skip *component* if you are unsure about which is the best component.
  Typo fixes that have no associated JIRA issue should be named following this pattern: `[hotfix][docs] Fix typo in event time introduction` or `[hotfix][javadocs] Expand JavaDoc for PuncuatedWatermarkGenerator`.

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Make sure that the change passes the automated tests, i.e., `mvn clean verify` passes. You can read more on how we use GitHub Actions for CI [here](https://nightlies.apache.org/flink/flink-kubernetes-operator-docs-main/docs/development/guide/#cicd).

  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message (including the JIRA id)

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.


**(The sections below can be removed for hotfixes of typos)**
-->

## What is the purpose of the change

*(For example: This pull request adds a new feature to periodically create and maintain savepoints through the `FlinkDeployment` custom resource.)*


## Brief change log

*(for example:)*
  - *Periodic savepoint trigger is introduced to the custom resource*
  - *The operator checks on reconciliation whether the required time has passed*
  - *The JobManager's dispose savepoint API is used to clean up obsolete savepoints*

## Verifying this change
<!--
Please make sure both new and modified tests in this PR follows the conventions defined in our code quality guide: https://flink.apache.org/contributing/code-style-and-quality-common.html#testing
-->
*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (100MB)*
  - *Extended integration test for recovery after master (JobManager) failure*
  - *Manually verified the change by running a 4 node cluster with 2 JobManagers and 4 TaskManagers, a stateful streaming program, and killing one JobManager and two TaskManagers during the execution, verifying that recovery happens correctly.*

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (yes / no)
  - The public API, i.e., is any changes to the `CustomResourceDescriptors`: (yes / no)
  - Core observer or reconciler logic that is regularly executed: (yes / no)

## Documentation

  - Does this pull request introduce a new feature? (yes / no)
  - If yes, how is the feature documented? (not applicable / docs / JavaDocs / not documented)
